### PR TITLE
fix int-bigint conversion issue in prepared statement

### DIFF
--- a/src/lua/internal/sysbench.sql.lua
+++ b/src/lua/internal/sysbench.sql.lua
@@ -396,7 +396,7 @@ function statement_methods.bind_create(self, btype, max_len)
    then
       param.type = sql_type.INT
       param.buffer = ffi.new('int[1]')
-      param.max_len = 8
+      param.max_len = 4
    elseif btype == sql_type.BIGINT
    then
       param.type = sql_type.BIGINT

--- a/src/lua/internal/sysbench.sql.lua
+++ b/src/lua/internal/sysbench.sql.lua
@@ -392,8 +392,12 @@ function statement_methods.bind_create(self, btype, max_len)
 
    if btype == sql_type.TINYINT or
       btype == sql_type.SMALLINT or
-      btype == sql_type.INT or
-      btype == sql_type.BIGINT
+      btype == sql_type.INT
+   then
+      param.type = sql_type.INT
+      param.buffer = ffi.new('int[1]')
+      param.max_len = 8
+   elseif btype == sql_type.BIGINT
    then
       param.type = sql_type.BIGINT
       param.buffer = ffi.new('int64_t[1]')


### PR DESCRIPTION
From lua files, sysbench treats all of ```TINYINT``` , ```SMALLINT```, ```INT``` and ```BIGINT```  as ```BIGINT``` which is:
1. Incorrect since they are different data_types
2. Unnecessary since all create tables use INTEGER in lua scripts
3. Might cause problem with data_type conversion/mapping at database level. 
