### PR TITLE
Fixed Idleconnection workload 

### DIFF
--- a/src/lua/idleconnection.lua
+++ b/src/lua/idleconnection.lua
@@ -6,6 +6,8 @@
 --    --pgsql-db=yugabyte --pgsql-port=5433 --pgsql-user=yugabyte --pgsql-host=127.0.0.1 --threads=10 run
 -- ----------------------------------------------------------------------
 
+require("oltp_common")
+
 function thread_init()
     -- create a connection
     drv = sysbench.sql.driver()

--- a/src/lua/idleconnection.lua
+++ b/src/lua/idleconnection.lua
@@ -25,3 +25,11 @@ function event()
     -- sleep for a second
     sleep(1)
 end
+
+-- ----------------------------------------------------------------------
+-- Overriding thread_done, as “stmt:close()” is not required for this workload. 
+-- ----------------------------------------------------------------------
+
+function thread_done()
+   con:disconnect()
+end


### PR DESCRIPTION
Fixed "idleconnection" workload:
- Added "oltp_common" to support "cleanup, create, load" phases.
- Override "thread_done" to avoid "attempt to index global 'stmt' (a nil value)" error.