### PR TITLE
Add benchmark references in lua makefile

### DIFF
--- a/src/lua/Makefile.am
+++ b/src/lua/Makefile.am
@@ -21,14 +21,14 @@ dist_pkgdata_SCRIPTS = bulk_insert.lua \
              oltp_insert.lua \
              oltp_multi_insert.lua \
              idleconnection.lua \
-			 oltp_index_scan.lua \
-			 oltp_join.lua \
-			 oltp_multi_value_insert.lua \
-			 oltp_primarykey_scan.lua \
-			 oltp_sequential_scan.lua \
-			 oltp_simple_ranges.lua \
-			 oltp_sum_scan.lua \
-			 select_one.lua \
+             oltp_index_scan.lua \
+             oltp_join.lua \
+             oltp_multi_value_insert.lua \
+             oltp_primarykey_scan.lua \
+             oltp_sequential_scan.lua \
+             oltp_simple_ranges.lua \
+             oltp_sum_scan.lua \
+             select_one.lua \
              oltp_read_only.lua \
              oltp_read_write.lua \
              oltp_point_select.lua \

--- a/src/lua/Makefile.am
+++ b/src/lua/Makefile.am
@@ -20,6 +20,15 @@ dist_pkgdata_SCRIPTS = bulk_insert.lua \
              oltp_delete.lua \
              oltp_insert.lua \
              oltp_multi_insert.lua \
+             idleconnection.lua \
+			 oltp_index_scan.lua \
+			 oltp_join.lua \
+			 oltp_multi_value_insert.lua \
+			 oltp_primarykey_scan.lua \
+			 oltp_sequential_scan.lua \
+			 oltp_simple_ranges.lua \
+			 oltp_sum_scan.lua \
+			 select_one.lua \
              oltp_read_only.lua \
              oltp_read_write.lua \
              oltp_point_select.lua \


### PR DESCRIPTION
- after adding the references, sysbench package is now able to recognise these custom benchmarks
- without this, it works when you are inside the sysbench code directory. But, outside the directory it gives following error:
```
$sysbench idleconnection
sysbench 1.1.0-0b5aea2 (using bundled LuaJIT 2.1.0-beta3)

FATAL: Cannot find benchmark 'idleconnection': no such built-in test, file or module
```